### PR TITLE
Add google repository to build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,6 +2,7 @@
 buildscript {
     repositories {
         jcenter()
+	google()
     }
 
     dependencies {


### PR DESCRIPTION
Added google repository to fix issue of not finding com.android.tools.build:gradle:3.0.1.

```
Starting a Gradle Daemon (subsequent builds will be faster)

FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring root project 'ExampleSpotifyApp'.
> Could not resolve all files for configuration ':classpath'.
   > Could not find com.android.tools.build:gradle:3.0.1.
     Searched in the following locations:
         https://jcenter.bintray.com/com/android/tools/build/gradle/3.0.1/gradle-3.0.1.pom
         https://jcenter.bintray.com/com/android/tools/build/gradle/3.0.1/gradle-3.0.1.jar
     Required by:
         project :

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.

* Get more help at https://help.gradle.org

BUILD FAILED in 17s
Could not install the app on the device, read the error above for details.
Make sure you have an Android emulator running or a device connected and have
set up your Android development environment:
https://facebook.github.io/react-native/docs/android-setup.html
```