### PR TITLE
React-native-spotify now works out of the box

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,6 @@
 buildscript {
     repositories {
         jcenter()
-        google()
     }
 
     dependencies {
@@ -14,6 +13,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 23
+    buildToolsVersion '26.0.2'
 
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
When creating a fresh react-native project with ``react-native init``, the current installation instructions at https://www.npmjs.com/package/@lufinkey/react-native-spotify result in a broken project. 
```
Could not find method google() for arguments [] on repository container.
```
The final line of the installation guide offers a solution: 

> If you have issues linking the module, please check that gradle is updated to the latest version and that your project is synced.

But that's definitely a dirty fix.
Updating gradle to the latest version might seem like the right thing to do in this case, but this would be ignoring the fact that react-native still ships with gradle 2.2.3 out of the box. As such, the project I'm _actually_ working on (which has many dependencies), will probably be better suited staying on the 2.2.3 version.

Up until now, I've been (temporarily) fixing this issue by just removing the google() line from ``node_modules/@lufinkey/react-native-spotify/android/build.gradle``. But after updating recently, patching the project like this has still been resulting in an error. 
```
buildToolsVersion is not specified.
```
It seems the ``buildToolsVersion '26.0.2'`` line is causing this issue, as it is missing from the npm version of the project, as opposed to master, where it can be found in the same build.gradle file on line 17.

removing the google line and adding the buildToolsVersion line seems like enough to get this module working out of the box.