### PR TITLE
Added events to send to JS

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,17 @@
+import {
+  DeviceEventEmitter,
+  Platform,
+  NativeEventEmitter,
+  NativeModules
+} from 'react-native';
 
-import { NativeModules } from 'react-native';
+const Spotify = NativeModules.Spotify;
 
-export default Spotify = NativeModules.Spotify;
+const eventEmitter = Platform.select({
+  ios: new NativeEventEmitter(Spotify),
+  android: DeviceEventEmitter
+});
+
+Spotify.events = eventEmitter;
+
+export default Spotify;

--- a/ios/RCTSpotify.h
+++ b/ios/RCTSpotify.h
@@ -1,8 +1,10 @@
 
 #if __has_include("RCTBridgeModule.h")
 #import "RCTBridgeModule.h"
+#import "RCTEventEmitter.h"
 #else
 #import <React/RCTBridgeModule.h>
+#import <React/RCTEventEmitter.h>
 #endif
 
 extern NSString* const RCTSpotifyErrorDomain;
@@ -28,7 +30,7 @@ typedef enum
 
 
 
-@interface RCTSpotify : NSObject <RCTBridgeModule>
+@interface RCTSpotify : RCTEventEmitter <RCTBridgeModule>
 
 +(NSError*)errorWithCode:(RCTSpotifyErrorCode)code description:(NSString*)description;
 


### PR DESCRIPTION
Added support for sending certain native events to the JS side. I use them to keep JS views in-sync with the native player. The events maintain parity between Android and iOS using DeviceEventEmitter and NativeEventEmitter respectively.

Support events include:

* didChangePlaybackStatus: sends a boolean of true or false
* didChangePosition: sends a position (in seconds) of current song playing
* didChangeMetadata: sends a metadata object matching the native metadata (ie: {prevTrack: ..., currentTrack: ..., nextTrack: ...})
* didFinishPlayback: sends a boolean of true when the audio delivery is complete

A few examples:

```
import Spotify from '@lufinkey/react-native-spotify';

Spotify.events.addListener(
      'didChangePlaybackStatus',
      (isPlaying) => {
        isPlaying
          ? this.props.dispatch(audioplayerPlaySuccess())
          : this.props.dispatch(audioplayerPauseSuccess());
      }
);
```

```
import Spotify from '@lufinkey/react-native-spotify';

Spotify.events.addListener(
      'didChangeMetadata',
      (metadata) => {
        this.props.dispatch(audioplayerGetMetadataSuccess(metadata));
      }
);
```

```
import Spotify from '@lufinkey/react-native-spotify';

Spotify.events.addListener(
      'didFinishPlayback',
      (finished) => {
        this.props.dispatch(audioplayerFinishedPlaying());
      }
);
```

```
Spotify.events.addListener(
      'didChangePosition',
      (position) => {
        const progress = position / this.state.duration;
        this.state.progress.setValue(position / this.state.duration);
    }
);
```