### PR TITLE
update submodule for spotify ios sdk path change

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "ios/external/SpotifySDK"]
 	path = ios/external/SpotifySDK
-	url = https://github.com/spotify/ios-sdk
+	url = https://github.com/spotify/ios-streaming-sdk
 	ignore = dirty


### PR DESCRIPTION
spotify have changed their ios repo as of september 11th

https://developer.spotify.com/documentation/ios/