### PR TITLE
Add support for linking via Cocoapods

### DIFF
--- a/RNSpotify.podspec
+++ b/RNSpotify.podspec
@@ -1,0 +1,21 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name         = "RNSpotify"
+  s.version      = package['version']
+  s.summary      = package['description']
+  s.license      = package['license']
+
+  s.authors      = package['author']
+  s.homepage     = package['repository']['url']
+  s.platform     = :ios, "9.0"
+
+  s.source       = { :git => package['repository']['url'], :tag => "v#{s.version}" }
+  s.source_files  = "ios/*.{h,m}"
+  s.vendored_frameworks = "ios/external/SpotifySDK/SpotifyAudioPlayback.framework", "ios/external/SpotifySDK/SpotifyAuthentication.framework", "ios/external/SpotifySDK/SpotifyMetadata.framework"
+
+  s.dependency 'React'
+  s.dependency 'RNEventEmitter'
+end


### PR DESCRIPTION
Moving forward, ReactNative [will start using CocoaPods](https://github.com/react-native-community/releases/issues/116) as the default linking mechanism. This adds a `.podspec` so linking will work correctly.

However, as this repo relies on `react-native-events` it needs https://github.com/lufinkey/react-native-events/pull/4 to be merged

### How to use

Put inside your project's `Podfile`:
```ruby
  pod 'RNEventEmitter', :path => '../node_modules/react-native-events'
  pod 'RNSpotify', :path => '../node_modules/rn-spotify-sdk'
```