### PR TITLE
Add support for Spotify's get recommendations / add tracks to playlist routes

### DIFF
--- a/src/Spotify.js
+++ b/src/Spotify.js
@@ -249,7 +249,7 @@ Spotify.getRecommendations = (artistIDs, genres, trackIDs, options) => {
 	}
 
 	const numSeeds = artistIDs.length + genres.length + trackIDs.length;
-	if (numSeeds === 0 || numSeeds > 5) {
+	if(numSeeds === 0 || numSeeds > 5) {
 		return Promise.reject(new Error("number of seeds must be between 1 and 5"));
 	}
 
@@ -258,6 +258,25 @@ Spotify.getRecommendations = (artistIDs, genres, trackIDs, options) => {
 	body['seed_genres'] = genres.join(',');
 	body['seed_tracks'] = trackIDs.join(',');
 	return Spotify.sendRequest('v1/recommendations', 'GET', body, false);
+}
+
+Spotify.addTracksToPlaylist = (playlistID, trackURIs, position, options) => {
+	if(playlistID == null) {
+		return Promise.reject(new Error("playlistID cannot be null"));
+	}
+
+	const numTracks = trackURIs.length;
+	if(numTracks === 0 || numTracks > 100) {
+		return Promise.reject(new Error("number of tracks must be between 1 and 100"));
+	}
+
+	const body = {...options};
+	body['uris'] = trackURIs;
+	if(position !== undefined) {
+		body['position'] = position;
+	}
+
+	return Spotify.sendRequest('v1/playlists/' + playlistID + '/tracks', 'POST', body, false);
 }
 
 

--- a/src/Spotify.js
+++ b/src/Spotify.js
@@ -237,4 +237,29 @@ Spotify.getMyTop = (type, options) => {
 
 
 
+Spotify.getRecommendations = (artistIDs, genres, trackIDs, options) => {
+	if(!(artistIDs instanceof Array)) {
+		return Promise.reject(new Error("artistIDs must be an array"));
+	}
+	if(!(genres instanceof Array)) {
+		return Promise.reject(new Error("genres must be an array"));
+	}
+	if(!(trackIDs instanceof Array)) {
+		return Promise.reject(new Error("trackIDs must be an array"));
+	}
+
+	const numSeeds = artistIDs.length + genres.length + trackIDs.length;
+	if (numSeeds === 0 || numSeeds > 5) {
+		return Promise.reject(new Error("number of seeds must be between 1 and 5"));
+	}
+
+	const body = {...options};
+	body['seed_artists'] = artistIDs.join(',');
+	body['seed_genres'] = genres.join(',');
+	body['seed_tracks'] = trackIDs.join(',');
+	return Spotify.sendRequest('v1/recommendations', 'GET', body, false);
+}
+
+
+
 export default Spotify;


### PR DESCRIPTION
This is just a small pull request which adds two new methods as below. I've tried to keep the code style as similar as possible to the existing methods available.

### New methods

**Get Recommendations**

`Spotify.getRecommendations(artistIDs, genres, trackIDs, options)`

_Returns an array of tracks that are recommended based on a given list of artistIDs, genres, and/or trackIDs (up to 5 as per Spotify docs)._

**Add Tracks To Playlist**

`Spotify.addTracksToPlaylist(playlistID, trackURIs, position, options)`

_Adds an array of tracks to a given playlist starting at a given position._