### PR TITLE
Make it compatible with "react-native link" and "autolinking"

### DIFF
--- a/react-native.config.js
+++ b/react-native.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  dependency: {
+    platforms: {
+      android: {
+        packageImportPath: 'com.lufinkey.react.spotify.RNSpotifyPackage',
+      },
+    },
+  },
+};


### PR DESCRIPTION
Fixes #139 

CLI looks for `packageImportPath` by parsing `AndroidManifest.xml`. This package ships with `android/external/SpotifySDK` which has such manifest as well.

Ending up with two AndroidManifests, CLI just picks the first one, in this case - the wrong one.

Setting a custom configuration (and shipping it to the npm) will let CLI aware of that and use the provided settings instead.

Documentation for this feature: https://github.com/react-native-community/cli/blob/master/docs/dependencies.md#platformsandroidpackageimportpath