### PR TITLE
Fix react-native.config.js

### DIFF
--- a/react-native.config.js
+++ b/react-native.config.js
@@ -2,7 +2,7 @@ module.exports = {
   dependency: {
     platforms: {
       android: {
-        packageImportPath: 'com.lufinkey.react.spotify.RNSpotifyPackage',
+        packageImportPath: 'import com.lufinkey.react.spotify.RNSpotifyPackage;',
       },
     },
   },


### PR DESCRIPTION
It was breaking the build on Android, since it would be
imported missing the 'import' keyword and a broken
react/PackageList.java would be generated.

Closes #150