### PR TITLE
(fix) Scenarios where the Spotify SDK returns an array response

### DIFF
--- a/ios/RNSpotify.m
+++ b/ios/RNSpotify.m
@@ -992,10 +992,10 @@ RCT_EXPORT_METHOD(seek:(double)position resolve:(RCTPromiseResolveBlock)resolve 
 					return;
 				}
 
-        id errorObj = nil;
-        if ([result isKindOfClass:[NSDictionary class]]) {
-          errorObj = result[@"error"];
-        }
+				id errorObj = nil;
+				if ([result isKindOfClass:[NSDictionary class]]) {
+					errorObj = result[@"error"];
+				}
 
 				if(errorObj != nil) {
 					id errorDescription = result[@"error_description"];

--- a/ios/RNSpotify.m
+++ b/ios/RNSpotify.m
@@ -991,8 +991,12 @@ RCT_EXPORT_METHOD(seek:(double)position resolve:(RCTPromiseResolveBlock)resolve 
 					[completion reject:[RNSpotifyError errorWithNSError:error]];
 					return;
 				}
-				
-				id errorObj = result[@"error"];
+
+        id errorObj = nil;
+        if ([result isKindOfClass:[NSDictionary class]]) {
+          errorObj = result[@"error"];
+        }
+
 				if(errorObj != nil) {
 					id errorDescription = result[@"error_description"];
 					if(errorDescription != nil) {


### PR DESCRIPTION
Some endpoints like https://developer.spotify.com/console/get-current-user-contains-saved-tracks for example, return an array, and break the doAPIRequest function.

Literally my first block in Objective-C so if there's a better way to add this in, feel free to update.

Thanks!